### PR TITLE
Replace /funding url with /thesis in site footer and homepage

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -160,7 +160,7 @@
 							read up on our funding and grants program.
 						</p>
 					</div>
-					<footer class="align-center"><a href="funding" class="button">Learn more &rarr;</a></footer>
+					<footer class="align-center"><a href="thesis" class="button">Learn more &rarr;</a></footer>
 				</div>
 			</div>
 		</div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -20,7 +20,7 @@
 					<li><a href="/"><strong>Home</strong></a></li>
 					<li><a href="/about">About</a></li>
 					<li><a href="/partners">Partners</a></li>
-					<li><a href="/funding">Funding</a></li>
+					<li><a href="/thesis">Thesis</a></li>
 					<li><a href="/disclosure">Disclosure</a></li>
 					<li><a href="https://grove.rainmatter.org">Forum</a></li>
 					<li><a href="https://listmonk.rainmatter.org/subscription/form">Newsletter</a></li>


### PR DESCRIPTION
The last commit replaced the `/funding` page with `/thesis` but the site footer and homepage links weren't updated. Clicking on those links from the project website currently leads to the GitHub Pages' default 404 page.

Merging this PR should fix the issue.

NB: I wasn't able to test the build since the project uses a Hugo version from nearly five years ago (v0.68.3). If it ain't broke, don't fix it, I guess.